### PR TITLE
Update moderators.json

### DIFF
--- a/moderators.json
+++ b/moderators.json
@@ -2,7 +2,10 @@
   "moderators": {
     "admins": [
       { "id": 121520, "name": "ArtOfCode" },
-      { "id": 73046, "name": "Undo" }
+      { "id": 73046, "name": "Undo" },
+      { "id": 62118, "name": "tripleee" },
+      { "id": 145827, "name": "angussidney" },
+      { "id": 66258, "name": "Andy" }
     ]
   }
 }


### PR DESCRIPTION
I had edited the first section of admins with the list from the Charcoal Wiki https://charcoal-se.org/people

Does everyone on the list go on, or is it only active users? Also did I edit it the right way?
